### PR TITLE
Add MQTT reconnection backoff logic

### DIFF
--- a/Garage.ino
+++ b/Garage.ino
@@ -52,7 +52,7 @@ void Connect()
       else
       {
         mqttLastConnectionTry = currentMillis;
-        mqttConnectionTimeout = min(mqttConnectionTimeout + random(5000, 30000), 300000);
+        mqttConnectionTimeout = min(mqttConnectionTimeout * 2 + random(0, 5000), 300000)
       }
     }
   }

--- a/Garage.ino
+++ b/Garage.ino
@@ -52,7 +52,7 @@ void Connect()
       else
       {
         mqttLastConnectionTry = currentMillis;
-        mqttConnectionTimeout = min(mqttConnectionTimeout * 2 + random(0, 5000), 300000)
+        mqttConnectionTimeout = min(mqttConnectionTimeout * 2 + random(0, 5000), 300000);
       }
     }
   }


### PR DESCRIPTION
Introduces a timeout and backoff mechanism for MQTT reconnection attempts to prevent rapid retries. The logic uses randomized intervals and caps the maximum delay, improving connection stability and reducing network load.