### PR TITLE
Improve MQTT reconnection backoff logic

### DIFF
--- a/Garage.ino
+++ b/Garage.ino
@@ -46,8 +46,10 @@ void Connect()
       {
         mqttClient.Publish(GARAGE_STATE, doorState == HIGH? "Closed" : "Open", true);
         mqttClient.Subscribe(GARAGE_CMD);
+
         mqttLastConnectionTry = currentMillis;
         mqttConnectionTimeout = 0;
+
       }
       else
       {
@@ -58,7 +60,8 @@ void Connect()
   }
   else
   {
-    mqttConnectionTimeout = min(mqttConnectionTimeout + random(5000, 30000), 300000);
+    mqttLastConnectionTry = currentMillis;
+    mqttConnectionTimeout = min(mqttConnectionTimeout * 2 + random(0, 5000), 300000);
   }
 }
 


### PR DESCRIPTION
Updated the MQTT reconnection logic to use exponential backoff with jitter, and reset the last connection attempt timestamp on failure. This should make reconnection attempts more robust and less aggressive.